### PR TITLE
Require a selection before Step 2 assessment

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -137,6 +137,7 @@ answers["ai_techniques"] = {
     "none_selected": none_selected,
 }
 
+has_any_selection = tech_ml_selected or tech_logic or none_selected
 uses_ai_techniques = (len(selected_ml) > 0) or tech_logic
 
 if none_selected:
@@ -150,6 +151,10 @@ if none_selected:
             "- Remove any other technique selections to avoid conflicting inputs."
         )
     export_json({"result": "Likely not an AI system", "reason": "Explicitly selected no AI techniques", "answers": answers})
+    st.stop()
+
+if not has_any_selection:
+    st.info("Select an option to continue the assessment.")
     st.stop()
 
 if not uses_ai_techniques:


### PR DESCRIPTION
## Summary
- prevent Step 2 from reporting a conclusion before any AI technique option is chosen
- add guidance prompting users to select an option before continuing the assessment

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d666a1c2548321aac6c85dfb43badc