### PR TITLE
Handle missing inference autonomy answers

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -226,9 +226,10 @@ else:
     rationale.append("Uses AI techniques and not limited to optimization‑only carve‑out.")
 
 # Enrich rationale with optional info
-if answers["inference_autonomy"]["infers_outputs"]:
+inference_autonomy = answers.get("inference_autonomy", {})
+if inference_autonomy.get("infers_outputs"):
     rationale.append("Confirms inference from inputs to outputs.")
-if answers["inference_autonomy"]["varying_autonomy"]:
+if inference_autonomy.get("varying_autonomy"):
     rationale.append("Operates with varying levels of autonomy (may still be human‑in-the-loop).")
 
 # -------- Display result


### PR DESCRIPTION
## Summary
- guard the optional inference/autonomy rationale from missing answers

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d66bbaea18832188d15fdc51b52f39