### PR TITLE
Remove obsolete caption from results view

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -753,6 +753,3 @@ render_decision_log()
 assessment = {"result": verdict, "rationale": rationale, "answers": answers, "decision_log": decision_log}
 export_assessment(assessment)
 
-st.caption(
-    "This tool reflects the decision structure in your illustration. For borderline cases, escalate for expert review and document assumptions."
-)


### PR DESCRIPTION
## Summary
- remove the final caption that advised escalating borderline cases for expert review

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d68311796883218120601124fad21b